### PR TITLE
baseテンプレートの整備など

### DIFF
--- a/project/app/templates/app/base.html
+++ b/project/app/templates/app/base.html
@@ -3,20 +3,16 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>作問くん</title>
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    {% block extracss %}{% endblock %}
+    {% load static %}
+    <title>{% block title %}{% endblock %}</title>
+    <link href="{% static 'css/style.css' %}" rel="stylesheet">
   </head>
   <body>
-    <div class="container">
-      <h1>作問くん</h1>
-      {% block content %}
-      {% endblock %}
-    </div>
+    {% block header %}{% endblock %}
+    <main>
+      {% block content %}{% endblock %}
+    </main>
 
-    <!-- Bootstrap JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     {% block extrajs %}{% endblock %}
   </body>
 </html>

--- a/project/app/templates/app/header_base.html
+++ b/project/app/templates/app/header_base.html
@@ -1,0 +1,11 @@
+{% extends "app/base.html" %}
+
+{% block header %}
+  <header>
+    <nav>
+      <a>ホーム</a>
+      <a>ユーザー情報</a>
+      <a>ログアウト</a>
+    </nav>
+  </header>
+{% endblock %}

--- a/project/app/templates/app/user_login.html
+++ b/project/app/templates/app/user_login.html
@@ -1,8 +1,14 @@
-{% extends 'app/base.html'%}
+{% extends 'app/header_base.html'%}
+{% block title %}login{% endblock %}
 
 {% block content %}
-<h1>ログイン</h1>
-<form placeholder="メールアドレス">
-<form placeholder="パスワード">
+<h1>作問くん</h1>
+<form>
+  <label for="email">メールアドレス</label>
+  <input id="email">
+  <label for="password">パスワード</label>
+  <input id="password">
+  <button>ログイン</button>
+</form>
 <a href="{% url 'app:register' %}">新規登録</a>
 {% endblock %}

--- a/project/app/templates/app/user_login.html
+++ b/project/app/templates/app/user_login.html
@@ -1,4 +1,4 @@
-{% extends 'app/header_base.html'%}
+{% extends 'app/base.html'%}
 {% block title %}login{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
baseテンプレートの整備などを行いました。
①base.htmlの継承にtitleとcontentを作成
②同じくheaderを作成
③header_base.htmlを作成して、headerを埋め込み
④cssファイルを作成
⑤bootstrapは使用しないので削除

これによって、ヘッダが必要ないページはbase.htmlをextendsして使用、titleとcontentの名前で埋め込みを行います。
ヘッダが必要なページでは、header_base.htmlをextendsして使用、上記の2つの名前で同じく埋め込みを行います。

[確認したこと]
htmlファイルをレンダリングして、ヘッダ要素と、メイン要素が表示されること
とりあえずcssはまだあてていません
cssファイルを編集すると反映すること