### PR TITLE
問題フォーム追加ボタン・削除ボタンを作成

### DIFF
--- a/project/app/static/css/style.css
+++ b/project/app/static/css/style.css
@@ -105,6 +105,10 @@ header > nav > a:nth-of-type(2) {
   background: #ff1500;
 }
 
+#question {
+  margin-top: 16px;
+}
+
 #create-test {
   margin-top: 12px;
   padding-left: 40px;

--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -13,7 +13,7 @@ addQuestionButton.addEventListener("click", () => {
 });
 
 removeQuestionButton.addEventListener("click", () => {
-  console.log("clicked");
+  removeQuestionForm();
   disableButton(removeQuestionButton);
   setTimeout(() => {
     enableButton(removeQuestionButton);
@@ -94,4 +94,13 @@ function disableButton(addQuestionButton) {
 function enableButton(addQuestionButton) {
   addQuestionButton.disabled = false;
   addQuestionButton.style.background = "#00bfff";
+}
+// 一つ目は除いて最後の要素を削除する
+function removeQuestionForm() {
+  // 親要素
+  const questions = document.getElementById("questions");
+  const lastIndex = questions.children.length - 1;
+  if (lastIndex < 1) return;
+  const removeQuestion = questions.children[lastIndex];
+  questions.removeChild(removeQuestion);
 }

--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const addQuestionButton = document.getElementById("addQuestionButton");
+const removeQuestionButton = document.getElementById("removeQuestionButton");
 
 addQuestionButton.addEventListener("click", () => {
   addQuestionForm();
@@ -10,6 +11,14 @@ addQuestionButton.addEventListener("click", () => {
     enableButton(addQuestionButton);
   }, 1000);
 });
+
+removeQuestionButton.addEventListener("click", () => {
+  console.log("clicked");
+  disableButton(removeQuestionButton);
+  setTimeout(() => {
+    enableButton(removeQuestionButton);
+  }, 1000);
+})
 
 function addQuestionForm() {
   // 要素を作成・属性の設定

--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -1,0 +1,71 @@
+"use strict";
+
+const addQuestionButton = document.getElementById("addQuestionButton");
+
+addQuestionButton.addEventListener("click", () => addQuestionForm());
+
+function addQuestionForm() {
+  // 要素を作成・属性の設定
+
+  // 親要素
+  const questions = document.getElementById("questions");
+  // 追加するまとめ要素
+  const question = document.createElement("li");
+  question.id = "question";
+  // タイトル
+  const title = document.createElement("h3");
+  title.textContent = `問題 ${questions.children.length + 1}`;
+  // 問題文の入力欄
+  const questionText = document.createElement("textarea");
+  questionText.placeholder = "問題文";
+  questionText.rows = 5;
+  questionText.cols = 96;
+  // 選択肢ラベル
+  const choicesLabel = document.createElement("label");
+  choicesLabel.className = "flex choiceies";
+  choicesLabel.innerHTML = "<p>選択肢</p><p>正答</p>";
+  // 選択肢リスト
+  const choicesList = document.createElement("ol");
+  choicesList.className = "choiceies";
+  // 4つの選択肢を作成・追加
+  for (let i=0; i<4; i++) {
+    const choiceItem = document.createElement("li");
+    choiceItem.className = "flex";
+
+    const choiceLabel = document.createElement("label");
+    choiceLabel.textContent = i + 1;
+
+    const choiceInput = document.createElement("input");
+
+    const choiceRadio = document.createElement("input");
+    choiceRadio.type = "radio";
+    choiceRadio.name = `correct-${questions.children.length + 1}`;
+
+    // 要素を連結
+    choiceItem.appendChild(choiceLabel);
+    choiceItem.appendChild(choiceInput);
+    choiceItem.appendChild(choiceRadio);
+    choicesList.appendChild(choiceItem);
+  }
+  // 解説ラベル
+  const commentaryLabel = document.createElement("label");
+  commentaryLabel.setAttribute("for", `commentary-${questions.children.length + 1}`);
+  commentaryLabel.className = "commentary";
+  commentaryLabel.textContent = "解説";
+  // 解説の入力欄
+  const commentaryText = document.createElement("textarea");
+  commentaryText.className = "commentary";
+  commentaryText.id = `commentary-${questions.children.length + 1}`;
+  commentaryText.placeholder = "解説文";
+  commentaryText.rows = 7;
+  commentaryText.cols = 96;
+
+  // 要素を連結
+  question.appendChild(title);
+  question.appendChild(questionText);
+  question.appendChild(choicesLabel);
+  question.appendChild(choicesList);
+  question.appendChild(commentaryLabel);
+  question.appendChild(commentaryText);
+  questions.appendChild(question);
+}

--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -2,7 +2,11 @@
 
 const addQuestionButton = document.getElementById("addQuestionButton");
 
-addQuestionButton.addEventListener("click", () => addQuestionForm());
+addQuestionButton.addEventListener("click", () => {
+  addQuestionForm();
+  // 連打防止のため1秒無効化
+  disableButton(addQuestionButton);
+});
 
 function addQuestionForm() {
   // 要素を作成・属性の設定
@@ -68,4 +72,9 @@ function addQuestionForm() {
   question.appendChild(commentaryLabel);
   question.appendChild(commentaryText);
   questions.appendChild(question);
+}
+
+function disableButton(addQuestionButton) {
+  addQuestionButton.disabled = true;
+  addQuestionButton.style.background = "gray";
 }

--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -6,6 +6,9 @@ addQuestionButton.addEventListener("click", () => {
   addQuestionForm();
   // 連打防止のため1秒無効化
   disableButton(addQuestionButton);
+  setTimeout(() => {
+    enableButton(addQuestionButton);
+  }, 1000);
 });
 
 function addQuestionForm() {
@@ -77,4 +80,9 @@ function addQuestionForm() {
 function disableButton(addQuestionButton) {
   addQuestionButton.disabled = true;
   addQuestionButton.style.background = "gray";
+}
+
+function enableButton(addQuestionButton) {
+  addQuestionButton.disabled = false;
+  addQuestionButton.style.background = "#00bfff";
 }

--- a/project/app/templates/app/base.html
+++ b/project/app/templates/app/base.html
@@ -13,7 +13,7 @@
       {% block content %}{% endblock %}
     </main>
 
-    {% block extrajs %}{% endblock %}
+    {% block extra_js %}{% endblock %}
   </body>
 </html>
 

--- a/project/app/templates/app/test/create.html
+++ b/project/app/templates/app/test/create.html
@@ -50,6 +50,11 @@
   </button>
 </div>
 <div class="button-area">
+  <button id="removeQuestionButton">
+    ー１番下の問題を削除する
+  </button>
+</div>
+<div class="button-area">
   <button type="submit">
     問題作成を完了する
   </button>

--- a/project/app/templates/app/test/create.html
+++ b/project/app/templates/app/test/create.html
@@ -9,7 +9,7 @@
 
 <ol id="questions">
   <li id="question">
-    <h3>問題１</h3>
+    <h3>問題1</h3>
     <textarea placeholder="問題文" form="create-test" rows="5" cols="96"></textarea>
 
     <label class="flex choiceies">
@@ -18,24 +18,24 @@
     </label>
     <ol class="choiceies">
       <li class="flex">
-        <label>１</label>
+        <label>1</label>
         <input>
-        <input type="radio" name="correct">
+        <input type="radio" name="correct-1">
       </li>
       <li class="flex">
-        <label>２</label>
+        <label>2</label>
         <input>
-        <input type="radio" name="correct">
+        <input type="radio" name="correct-1">
       </li>
       <li class="flex">
-        <label>３</label>
+        <label>3</label>
         <input>
-        <input type="radio" name="correct">
+        <input type="radio" name="correct-1">
       </li>
       <li class="flex">
-        <label>４</label>
+        <label>4</label>
         <input>
-        <input type="radio" name="correct">
+        <input type="radio" name="correct-1">
       </li>
     </ol>
 
@@ -45,7 +45,7 @@
 </ol>
 
 <div class="button-area">
-  <button>
+  <button id="addQuestionButton">
     ＋問題を追加する
   </button>
 </div>
@@ -54,4 +54,9 @@
     問題作成を完了する
   </button>
 </div>
+{% endblock %}
+
+{% load static %}
+{% block extra_js %}
+<script src="{% static 'js/create.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
問題フォームを追加・削除するためのボタンを作成しました。
- どちらも押下後１秒間は再使用不可にしました。
- １秒がわかりやすいように灰色に変わって、戻るようにしました。
- 問題フォームが一つのみの時は削除を行わないようにしました。
- 削除は一番下の要素を一つのみです。
- 問題番号などの部分にも適切な数字を振ってあります。

画面上で追加と削除を行って、不具合はなさそうでした。
