### PR TITLE
テスト一覧(トップ)画面の削除ボタンとモーダルを連携させました #26

### DIFF
--- a/project/app/static/css/style.css
+++ b/project/app/static/css/style.css
@@ -274,3 +274,41 @@ a.login-block {
   color: #fff;
   margin-left: 16px;
 }
+
+.modal {
+  width: 400px;
+  background: #fff;
+  height: 240px;
+  text-align: center;
+  padding: 16px 40px;
+  border: 1px solid black;
+  border-radius: 4px;
+}
+
+.modal > h1,
+.modal > p {
+  font-size: 1.5rem;
+  margin: 8px 0;
+}
+
+.modal > label {
+  font-size: 1.25rem;
+}
+
+.modal > .flex {
+  margin-top: 24px;
+}
+
+.modal > .flex > button {
+  width: 120px;
+  height: 32px;
+  margin: 0 auto;
+  font-size: 1.25rem;
+  color: #fff;
+  background: #00bfff;
+  border-radius: 4px;
+}
+
+.modal > .flex > button:nth-of-type(1) {
+  background: #ff1500;
+}

--- a/project/app/static/css/style.css
+++ b/project/app/static/css/style.css
@@ -50,6 +50,10 @@ li {
   display: flex;
 }
 
+.hidden {
+  display: none;
+}
+
 header > nav > a:nth-of-type(2) {
   margin-left: auto;
   color: #fff;
@@ -92,8 +96,9 @@ header > nav > a:nth-of-type(2) {
   gap: 8px;
 }
 
-.function-buttons > a {
-  width: 40px;
+.function-buttons > a,
+.function-buttons > button {
+  width: 48px;
   color: #fff;
 }
 
@@ -101,8 +106,9 @@ header > nav > a:nth-of-type(2) {
   width: 80px;
 }
 
-.function-buttons > a:nth-of-type(3) {
+.function-buttons > button {
   background: #ff1500;
+  font-size: 1rem;
 }
 
 #question {
@@ -283,6 +289,7 @@ a.login-block {
   padding: 16px 40px;
   border: 1px solid black;
   border-radius: 4px;
+  margin: 40px auto;
 }
 
 .modal > h1,

--- a/project/app/static/js/index.js
+++ b/project/app/static/js/index.js
@@ -1,10 +1,14 @@
 "use strict";
 
-function toggleModal() {
+function toggleModal(testTitle) {
   // mainタグのhidden切り替え
   const homeMain = document.getElementsByClassName("home-main")[0];
   homeMain.classList.toggle("hidden");
   // modalのhidden切り替え
   const modal = document.getElementsByClassName("modal")[0];
   modal.classList.toggle("hidden");
+
+  if (testTitle) {
+    document.getElementById("test-title-viewer").textContent = testTitle;
+  }
 }

--- a/project/app/static/js/index.js
+++ b/project/app/static/js/index.js
@@ -1,0 +1,10 @@
+"use strict";
+
+function toggleModal() {
+  // mainタグのhidden切り替え
+  const homeMain = document.getElementsByClassName("home-main")[0];
+  homeMain.classList.toggle("hidden");
+  // modalのhidden切り替え
+  const modal = document.getElementsByClassName("modal")[0];
+  modal.classList.toggle("hidden");
+}

--- a/project/app/templates/app/test/index.html
+++ b/project/app/templates/app/test/index.html
@@ -70,7 +70,7 @@
       </tr>
     </thead>
 
-    <tbody>
+    <tbody id="test-list">
       <tr>
         <td>
           <h3>クイズ１</h3>
@@ -82,7 +82,7 @@
           <div class="function-buttons">
             <a href="" class="link-button">回答確認</a>
             <a href="" class="link-button">編集</a>
-            <a href="" class="link-button">削除</a>
+            <button class="link-button" onclick="toggleModal()">削除</button>
           </div>
         </td>
       </tr>
@@ -98,7 +98,7 @@
           <div class="function-buttons">
             <a href="" class="link-button">回答確認</a>
             <a href="" class="link-button">編集</a>
-            <a href="" class="link-button">削除</a>
+            <button class="link-button" onclick="toggleModal()">削除</button>
           </div>
         </td>
       </tr>
@@ -114,7 +114,7 @@
           <div class="function-buttons">
             <a href="" class="link-button">回答確認</a>
             <a href="" class="link-button">編集</a>
-            <a href="" class="link-button">削除</a>
+            <button class="link-button" onclick="toggleModal()">削除</button>
           </div>
         </td>
       </tr>
@@ -123,4 +123,9 @@
 </div>
 
 {% include "app/test/modal/confirm_test_deletion.html" %}
+
+{% load static %}
+{% block extra_js %}
+<script src="{% static 'js/index.js' %}"></script>
+{% endblock %}
 {% endblock %}

--- a/project/app/templates/app/test/index.html
+++ b/project/app/templates/app/test/index.html
@@ -82,7 +82,7 @@
           <div class="function-buttons">
             <a href="" class="link-button">回答確認</a>
             <a href="" class="link-button">編集</a>
-            <button class="link-button" onclick="toggleModal()">削除</button>
+            <button class="link-button" onclick="toggleModal('クイズ１')">削除</button>
           </div>
         </td>
       </tr>
@@ -98,7 +98,7 @@
           <div class="function-buttons">
             <a href="" class="link-button">回答確認</a>
             <a href="" class="link-button">編集</a>
-            <button class="link-button" onclick="toggleModal()">削除</button>
+            <button class="link-button" onclick="toggleModal('クイズ２')">削除</button>
           </div>
         </td>
       </tr>
@@ -114,7 +114,7 @@
           <div class="function-buttons">
             <a href="" class="link-button">回答確認</a>
             <a href="" class="link-button">編集</a>
-            <button class="link-button" onclick="toggleModal()">削除</button>
+            <button class="link-button" onclick="toggleModal('クイズ３')">削除</button>
           </div>
         </td>
       </tr>

--- a/project/app/templates/app/test/index.html
+++ b/project/app/templates/app/test/index.html
@@ -117,4 +117,6 @@
     </tr>
   </table>
 </div>
+
+{% include "app/test/modal/confirm_test_deletion.html" %}
 {% endblock %}

--- a/project/app/templates/app/test/index.html
+++ b/project/app/templates/app/test/index.html
@@ -58,63 +58,67 @@
     </li>
     </ul>
 
-    <h2>作成テスト一覧</h2>
+  <h2>作成テスト一覧</h2>
   <table>
-    <tr>
-      <th>テストタイトル</th>
-      <th>作成日時</th>
-      <th>更新日時</th>
-      <th>問題数</th>
-      <th>(機能ボタン)</th>
-    </tr>
+    <thead>
+      <tr>
+        <th>テストタイトル</th>
+        <th>作成日時</th>
+        <th>更新日時</th>
+        <th>問題数</th>
+        <th>(機能ボタン)</th>
+      </tr>
+    </thead>
 
-    <tr>
-      <td>
-        <h3>クイズ１</h3>
-      </td>
-      <td>□</td>
-      <td>□</td>
-      <td>□</td>
-      <td>
-        <nav class="function-buttons">
-          <a href="" class="link-button">回答確認</a>
-          <a href="" class="link-button">編集</a>
-          <a href="" class="link-button">削除</a>
-        </nav>
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <h3>クイズ２</h3>
-      </td>
-      <td>□</td>
-      <td>□</td>
-      <td>□</td>
-      <td>
-        <nav class="function-buttons">
-          <a href="" class="link-button">回答確認</a>
-          <a href="" class="link-button">編集</a>
-          <a href="" class="link-button">削除</a>
-        </nav>
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <h3>クイズ３</h3>
-      </td>
-      <td>□</td>
-      <td>□</td>
-      <td>□</td>
-      <td>
-        <nav class="function-buttons">
-          <a href="" class="link-button">回答確認</a>
-          <a href="" class="link-button">編集</a>
-          <a href="" class="link-button">削除</a>
-        </nav>
-      </td>
-    </tr>
+    <tbody>
+      <tr>
+        <td>
+          <h3>クイズ１</h3>
+        </td>
+        <td>□</td>
+        <td>□</td>
+        <td>□</td>
+        <td>
+          <div class="function-buttons">
+            <a href="" class="link-button">回答確認</a>
+            <a href="" class="link-button">編集</a>
+            <a href="" class="link-button">削除</a>
+          </div>
+        </td>
+      </tr>
+      
+      <tr>
+        <td>
+          <h3>クイズ２</h3>
+        </td>
+        <td>□</td>
+        <td>□</td>
+        <td>□</td>
+        <td>
+          <div class="function-buttons">
+            <a href="" class="link-button">回答確認</a>
+            <a href="" class="link-button">編集</a>
+            <a href="" class="link-button">削除</a>
+          </div>
+        </td>
+      </tr>
+      
+      <tr>
+        <td>
+          <h3>クイズ３</h3>
+        </td>
+        <td>□</td>
+        <td>□</td>
+        <td>□</td>
+        <td>
+          <div class="function-buttons">
+            <a href="" class="link-button">回答確認</a>
+            <a href="" class="link-button">編集</a>
+            <a href="" class="link-button">削除</a>
+          </div>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </div>
 

--- a/project/app/templates/app/test/modal/confirm_test_deletion.html
+++ b/project/app/templates/app/test/modal/confirm_test_deletion.html
@@ -2,7 +2,7 @@
   <h1>テストを削除します</h1>
   <p>よろしいですか？</p>
   <label>テスト名</label>
-  <p>{テスト名表示予定}</p>
+  <p id="test-title-viewer">テスト名を表示します</p>
   <div class="flex">
     <button>削除する</button>
     <button id="close-modal-button" onclick="toggleModal()">戻る</button>

--- a/project/app/templates/app/test/modal/confirm_test_deletion.html
+++ b/project/app/templates/app/test/modal/confirm_test_deletion.html
@@ -3,4 +3,8 @@
   <p>よろしいですか？</p>
   <label>テスト名</label>
   <p>テスト名表示予定</p>
+  <div class="flex">
+    <button>削除する</button>
+    <button>戻る</button>
+  </div>
 </div>

--- a/project/app/templates/app/test/modal/confirm_test_deletion.html
+++ b/project/app/templates/app/test/modal/confirm_test_deletion.html
@@ -2,9 +2,9 @@
   <h1>テストを削除します</h1>
   <p>よろしいですか？</p>
   <label>テスト名</label>
-  <p>テスト名表示予定</p>
+  <p>{テスト名表示予定}</p>
   <div class="flex">
     <button>削除する</button>
-    <button>戻る</button>
+    <button id="close-modal-button" onclick="toggleModal()">戻る</button>
   </div>
 </div>

--- a/project/app/templates/app/test/modal/confirm_test_deletion.html
+++ b/project/app/templates/app/test/modal/confirm_test_deletion.html
@@ -1,7 +1,6 @@
-{% extends 'app/header_base.html' %}
-{% block title %}テスト削除{% endblock %}
-
-{% block content %}
-<h1>テストを削除してもよろしいですか。</h1>
-<a href="{% url 'app:home' %}">ホームに戻る</a>
-{% endblock %}
+<div class="modal hidden">
+  <h1>テストを削除します</h1>
+  <p>よろしいですか？</p>
+  <label>テスト名</label>
+  <p>テスト名表示予定</p>
+</div>


### PR DESCRIPTION
- 削除ボタンを押すとモーダルが現れて一覧画面が隠れる、
- モーダルを閉じるボタンを押すとモーダルが閉じて一覧画面が現れる、
という実装を行いました。

- 押したテストの名前がモーダル内に表示されるようにしました。
こちらはクリックで実行される関数に引数で渡す形にしました。
今はべた書きですが、今後DTLでのループに書き換えるタイミングで変数を埋め込む予定です。

試したこと
操作してみた感じ想定通りに動いていると思います。