### PR TITLE
テスト作成をフロント操作でできるようにしました。 #27

### DIFF
--- a/project/app/static/css/style.css
+++ b/project/app/static/css/style.css
@@ -11,7 +11,7 @@ main {
 header,
 .home-main,
 #create-test,
-#question,
+.question,
 .button-area,
 .creation-successful {
   background: #fff;
@@ -111,7 +111,7 @@ header > nav > a:nth-of-type(2) {
   font-size: 1rem;
 }
 
-#question {
+.question {
   margin-top: 16px;
 }
 

--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -39,6 +39,7 @@ function addQuestionForm() {
   questionText.setAttribute("form", "create-test");
   questionText.rows = 5;
   questionText.cols = 96;
+  questionText.required = true;
   // 選択肢ラベル
   const choicesLabel = document.createElement("label");
   choicesLabel.className = "flex choiceies";

--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -58,12 +58,14 @@ function addQuestionForm() {
     const choiceNumber = i + 1;
     choiceInput.name = `choice_${questionNumber}_${choiceNumber}`;
     choiceInput.setAttribute("form", "create-test");
+    if (i < 2) choiceInput.required = true;
 
     const choiceRadio = document.createElement("input");
     choiceRadio.value = choiceNumber;
     choiceRadio.type = "radio";
     choiceRadio.name = `correct_${questionNumber}`;
     choiceRadio.setAttribute("form", "create-test");
+    if (i < 1) choiceRadio.required = true;
 
     // 要素を連結
     choiceItem.appendChild(choiceLabel);

--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -25,15 +25,18 @@ function addQuestionForm() {
 
   // 親要素
   const questions = document.getElementById("questions");
+  const questionNumber = questions.children.length + 1;
   // 追加するまとめ要素
   const question = document.createElement("li");
   question.classList.add("question");
   // タイトル
   const title = document.createElement("h3");
-  title.textContent = `問題 ${questions.children.length + 1}`;
+  title.textContent = `問題 ${questionNumber}`;
   // 問題文の入力欄
   const questionText = document.createElement("textarea");
+  questionText.name = `question_text_${questionNumber}`;
   questionText.placeholder = "問題文";
+  questionText.setAttribute("form", "create-test");
   questionText.rows = 5;
   questionText.cols = 96;
   // 選択肢ラベル
@@ -52,10 +55,15 @@ function addQuestionForm() {
     choiceLabel.textContent = i + 1;
 
     const choiceInput = document.createElement("input");
+    const choiceNumber = i + 1;
+    choiceInput.name = `choice_${questionNumber}_${choiceNumber}`;
+    choiceInput.setAttribute("form", "create-test");
 
     const choiceRadio = document.createElement("input");
+    choiceRadio.value = choiceNumber;
     choiceRadio.type = "radio";
-    choiceRadio.name = `correct-${questions.children.length + 1}`;
+    choiceRadio.name = `correct_${questionNumber}`;
+    choiceRadio.setAttribute("form", "create-test");
 
     // 要素を連結
     choiceItem.appendChild(choiceLabel);
@@ -65,17 +73,18 @@ function addQuestionForm() {
   }
   // 解説ラベル
   const commentaryLabel = document.createElement("label");
-  commentaryLabel.setAttribute("for", `commentary-${questions.children.length + 1}`);
+  commentaryLabel.setAttribute("for", `commentary-${questionNumber}`);
   commentaryLabel.className = "commentary";
   commentaryLabel.textContent = "解説";
   // 解説の入力欄
   const commentaryText = document.createElement("textarea");
+  commentaryText.name = "commentary";
   commentaryText.className = "commentary";
-  commentaryText.id = `commentary-${questions.children.length + 1}`;
+  commentaryText.id = `commentary-${questionNumber}`;
   commentaryText.placeholder = "解説文";
   commentaryText.rows = 7;
   commentaryText.cols = 96;
-
+  commentaryText.setAttribute("form", "create-test");
   // 要素を連結
   question.appendChild(title);
   question.appendChild(questionText);

--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -27,7 +27,7 @@ function addQuestionForm() {
   const questions = document.getElementById("questions");
   // 追加するまとめ要素
   const question = document.createElement("li");
-  question.id = "question";
+  question.classList.add("question");
   // タイトル
   const title = document.createElement("h3");
   title.textContent = `問題 ${questions.children.length + 1}`;

--- a/project/app/templates/app/test/create.html
+++ b/project/app/templates/app/test/create.html
@@ -9,7 +9,7 @@
 </form>
 
 <ol id="questions">
-  <li id="question">
+  <li class="question">
     <h3>問題1</h3>
     <textarea name="question_text_1" placeholder="問題文" form="create-test" rows="5" cols="96"></textarea>
 
@@ -40,8 +40,8 @@
       </li>
     </ol>
 
-    <label for="commentary" class="commentary">解説</label>
-    <textarea name="commentary" class="commentary" id="commentary" placeholder="解説文" rows="7" cols="96" form="create-test"></textarea>
+    <label for="commentary-1" class="commentary">解説</label>
+    <textarea name="commentary" class="commentary" id="commentary-1" placeholder="解説文" rows="7" cols="96" form="create-test"></textarea>
   </li>
 </ol>
 

--- a/project/app/templates/app/test/create.html
+++ b/project/app/templates/app/test/create.html
@@ -2,15 +2,16 @@
 {% block title %}テスト作成{% endblock %}
 
 {% block content %}
-<form id="create-test">
+<form id="create-test" method="post">
   <label for="test-title">テストタイトル</label>
-  <input id="test-title">
+  <input name="title" id="test-title">
+  {% csrf_token %}
 </form>
 
 <ol id="questions">
   <li id="question">
     <h3>問題1</h3>
-    <textarea placeholder="問題文" form="create-test" rows="5" cols="96"></textarea>
+    <textarea name="question_text_1" placeholder="問題文" form="create-test" rows="5" cols="96"></textarea>
 
     <label class="flex choiceies">
       <p>選択肢</p>
@@ -19,28 +20,28 @@
     <ol class="choiceies">
       <li class="flex">
         <label>1</label>
-        <input>
-        <input type="radio" name="correct-1">
+        <input name="choice_1_1" form="create-test">
+        <input value="1" type="radio" name="correct_1" form="create-test" required>
       </li>
       <li class="flex">
         <label>2</label>
-        <input>
-        <input type="radio" name="correct-1">
+        <input name="choice_1_2" form="create-test">
+        <input value="2" type="radio" name="correct_1" form="create-test">
       </li>
       <li class="flex">
         <label>3</label>
-        <input>
-        <input type="radio" name="correct-1">
+        <input name="choice_1_3" form="create-test">
+        <input value="3" type="radio" name="correct_1" form="create-test">
       </li>
       <li class="flex">
         <label>4</label>
-        <input>
-        <input type="radio" name="correct-1">
+        <input name="choice_1_4" form="create-test">
+        <input value="4" type="radio" name="correct_1" form="create-test">
       </li>
     </ol>
 
     <label for="commentary" class="commentary">解説</label>
-    <textarea class="commentary" id="commentary" placeholder="解説文" rows="7" cols="96"></textarea>
+    <textarea name="commentary" class="commentary" id="commentary" placeholder="解説文" rows="7" cols="96" form="create-test"></textarea>
   </li>
 </ol>
 
@@ -55,7 +56,7 @@
   </button>
 </div>
 <div class="button-area">
-  <button type="submit">
+  <button type="submit" form="create-test">
     問題作成を完了する
   </button>
 </div>

--- a/project/app/templates/app/test/create.html
+++ b/project/app/templates/app/test/create.html
@@ -4,13 +4,13 @@
 {% block content %}
 <form id="create-test" method="post">
   <label for="test-title">テストタイトル</label>
-  <input name="title" id="test-title">
+  <input name="title" id="test-title" required>
   {% csrf_token %}
 </form>
 
 <ol id="questions">
   <li class="question">
-    <h3>問題1</h3>
+    <h3>問題 1</h3>
     <textarea name="question_text_1" placeholder="問題文" form="create-test" rows="5" cols="96"></textarea>
 
     <label class="flex choiceies">
@@ -20,12 +20,12 @@
     <ol class="choiceies">
       <li class="flex">
         <label>1</label>
-        <input name="choice_1_1" form="create-test">
+        <input name="choice_1_1" form="create-test" required>
         <input value="1" type="radio" name="correct_1" form="create-test" required>
       </li>
       <li class="flex">
         <label>2</label>
-        <input name="choice_1_2" form="create-test">
+        <input name="choice_1_2" form="create-test" required>
         <input value="2" type="radio" name="correct_1" form="create-test">
       </li>
       <li class="flex">

--- a/project/app/templates/app/test/create.html
+++ b/project/app/templates/app/test/create.html
@@ -11,7 +11,7 @@
 <ol id="questions">
   <li class="question">
     <h3>問題 1</h3>
-    <textarea name="question_text_1" placeholder="問題文" form="create-test" rows="5" cols="96"></textarea>
+    <textarea name="question_text_1" placeholder="問題文" form="create-test" rows="5" cols="96" required></textarea>
 
     <label class="flex choiceies">
       <p>選択肢</p>


### PR DESCRIPTION
デフォルトformとJavaScriptによる追加form両方にて、適切なformDataを送信してTests・Questions・Question Choicesに登録ができるようになりました。

以下の入力欄を必須に設定しました。
- 問題文
- 各問題ごとラジオボタンいずれか一つ必須
- 選択肢の一つ目と二つ目の入力

試したこと
実際に操作して、問題①と問題②を含むクイズを作成、データベースに想定通りのデータが入っていることをadminで確認しました。