### PR TITLE
テスト作成の修正

### DIFF
--- a/project/app/static/js/create.js
+++ b/project/app/static/js/create.js
@@ -81,7 +81,7 @@ function addQuestionForm() {
   commentaryLabel.textContent = "解説";
   // 解説の入力欄
   const commentaryText = document.createElement("textarea");
-  commentaryText.name = "commentary";
+  commentaryText.name = `commentary_${questionNumber}`;
   commentaryText.className = "commentary";
   commentaryText.id = `commentary-${questionNumber}`;
   commentaryText.placeholder = "解説文";

--- a/project/app/templates/app/test/create.html
+++ b/project/app/templates/app/test/create.html
@@ -41,7 +41,7 @@
     </ol>
 
     <label for="commentary-1" class="commentary">解説</label>
-    <textarea name="commentary" class="commentary" id="commentary-1" placeholder="解説文" rows="7" cols="96" form="create-test"></textarea>
+    <textarea name="commentary_1" class="commentary" id="commentary-1" placeholder="解説文" rows="7" cols="96" form="create-test"></textarea>
   </li>
 </ol>
 

--- a/project/app/views/test.py
+++ b/project/app/views/test.py
@@ -48,7 +48,7 @@ def create(request):
                 if not question_text:
                     break
                 correct_choice = request.POST.get(f'correct_{question_count}')
-                explanation = request.POST.get('commentary')
+                explanation = request.POST.get(f'commentary_{question_count}')
                 print('question_text', 'correct_choice', 'explanation')
 
                 # Questionの作成


### PR DESCRIPTION
解説が2問目以降に反映されていなかったため変更

テスト作成の部分で、解説が2問目以降保存されていませんでしたので、問題文や選択肢のように、
<textarea>のnameを commentary_1のようにしていただけませんか
create.jsのcommentary.nameの部分も{questionNumber}をつけていただきたいです。