### PR TITLE
[feat] テスト編集のロジックを作成

### DIFF
--- a/project/app/models.py
+++ b/project/app/models.py
@@ -59,6 +59,7 @@ class Test(models.Model):
         verbose_name='ユーザーID', 
         on_delete=models.PROTECT,
         db_column='userid',
+        related_name='tests',
         
         # デバッグ中のみ
         null=True,
@@ -104,9 +105,10 @@ class QuestionChoice(models.Model):
     questionid = models.ForeignKey(
         Question, 
         verbose_name='問題ID', 
-        on_delete=models.PROTECT,
-        db_column='questionid'
-    )
+        on_delete=models.CASCADE,
+        db_column='questionid',
+        related_name='choices',
+        )
     
     text = models.TextField('選択肢文')
     created_at = models.DateTimeField('作成日時', default=timezone.now)

--- a/project/app/urls.py
+++ b/project/app/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
     path('test/create/', test.create, name='test_create'),
     path('test/creation_successful/<int:testid>/', test.creation_successful, name='creation_successful'),
     path('test/detail/<int:testid>/', test.test_detail, name='test_detail'),
-    path('test/update/<int:testid>/', test.test_update, name='test_update'),
+    # path('test/update/<int:testid>/', test.test_update, name='test_update'),
     path('test/modal/confirm_test_deletion/', test.test_delete, name='test_delete'),
     path('test/<int:testid>/results', exam.exam_result_list, name='exam_result_list'),
 

--- a/project/app/views/test.py
+++ b/project/app/views/test.py
@@ -1,8 +1,10 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.db.models import Count
+from django.http import JsonResponse
+from django.utils import timezone
 from app.forms.test import TestForm
-from app.models import User, Test, Question, QuestionChoice
-
+from app.models import Test, Question, QuestionChoice
+import json
 
 # ホーム画面（テスト一覧）
 def home(request):
@@ -96,31 +98,78 @@ def creation_successful(request, testid):
 
 # テスト詳細
 def test_detail(request, testid):
+    # テストIDに基づいてTestオブジェクトを取得
     test = get_object_or_404(Test, id=testid)
-    context = {
-        'test': test
-    }
-    return render(request, 'app/test/detail.html', context)
+    
+    # テストに関連する質問と選択肢を取得
+    questions = test.questions.prefetch_related('choices').all()
 
-
-# テスト編集
-def test_update(request, testid=None):
-    test = get_object_or_404(Test, pk=testid)
-
+    # **リクエストメソッドに基づいて処理を分岐**
     if request.method == 'POST':
-        form = TestForm(request.POST, instance=test)
-        if form.is_valid():
-            form.save()
-            return redirect('app:home')
-    else:
-        form = TestForm(instance=test)
+        try:
+            if 'update_question' in request.POST:  # 質問更新フォームの送信
+                question_id = request.POST.get('question_id')
+                question = get_object_or_404(Question, id=int(question_id))
 
+                # 質問のテキストを更新
+                question.text = request.POST.get('text', question.text)
+                question.updated_at = timezone.now()
+
+                # 正解の選択肢を更新
+                correct_choice_id = request.POST.get('correct_choice')
+                if correct_choice_id:
+                    correct_choice = get_object_or_404(QuestionChoice, id=correct_choice_id)
+                    question.correct_choice = correct_choice
+
+                question.save()
+
+                # 選択肢の更新
+                for key, value in request.POST.items():
+                    if key.startswith('choice_'):
+                        choice_id = key.split('_')[1]
+                        choice = get_object_or_404(QuestionChoice, id=choice_id)
+                        choice.text = value
+                        choice.updated_at = timezone.now()
+                        choice.save()
+
+                # Testのupdated_atを更新
+                test.updated_at = timezone.now()
+                test.save()
+
+                return redirect('app:test_detail', testid=testid)
+            
+            # 質問削除フォームの送信かどうかを確認
+            elif 'delete_question' in request.POST:
+                question_id = request.POST.get('question_id')
+                question = get_object_or_404(Question, id=question_id)
+                
+                # 関連するQuestionChoiceを削除
+                question.choices.all().delete()
+
+                # Question を削除
+                question.delete()
+
+                # Testのupdated_atを更新
+                test.updated_at = timezone.now()
+                test.save()
+                
+                # 削除成功のレスポンスを返す
+                return JsonResponse({'status': 'success', 'message': '削除が完了しました。'})
+
+        
+        # 例外が発生した場合
+        except Exception as e:
+            # エラーメッセージを返す
+            return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
+
+    # テンプレートに渡すコンテキスト
     context = {
-        'form': form,
-        'testid': testid
+        'test': test,
+        'questions': questions,
     }
     
-    return render(request, 'app/test/update.html', context)
+    # 'app/test/detail.html'テンプレートをレンダリングして返す
+    return render(request, 'app/test/detail.html', context)
 
 
 # テスト削除


### PR DESCRIPTION
テスト編集のロジックを作成しました。

・問題の編集
テキストと選択肢を更新できるようにしました。

・質問の削除
質問を削除すると、関連する選択肢も削除されるようにしました。

・フォームの送信方法
POSTリクエストのフォームの名前を update_question / delete_question で判別するようにしました。
フロントエンドで送信するデータに update_question または delete_question を含めてほしいです。


